### PR TITLE
Handling values < needed Amount length

### DIFF
--- a/BankFileParsers/Helpers/BaiFileHelpers.cs
+++ b/BankFileParsers/Helpers/BaiFileHelpers.cs
@@ -71,8 +71,10 @@ namespace BankFileParsers
 
         public static decimal GetAmount(string amount, string currencyCode)
         {
+            var neededLength = GetDecimalPlaces(currencyCode);
             if (string.IsNullOrEmpty(amount)) return 0;
-            amount = amount.Insert(amount.Length - GetDecimalPlaces(currencyCode), ".");
+            if (amount.Length < neededLength) amount = amount.PadLeft(neededLength+1, '0');
+            amount = amount.Insert(amount.Length - neededLength, ".");
             return decimal.Parse(amount);
         }
 


### PR DESCRIPTION
If an amount is passed in and the length is less than the needed length, it would crash, this will pad the value with zeros, so it will now pass

so 7 would return 0.07 if the currency type is USD

This should fix #3 
