### PR TITLE
Ensure TextList is Populated With Each Text Line

### DIFF
--- a/BankFileParsers/Classes/Detail.cs
+++ b/BankFileParsers/Classes/Detail.cs
@@ -115,7 +115,22 @@ namespace BankFileParsers
 
         private void CreateTextDictionary()
         {
-            foreach (var item in TextList)
+            var dictionaryList = new List<string>();
+            var fields = Text.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var field in fields)
+            {
+                if (dictionaryList.Count > 0 && !field.Contains(":"))
+                {
+                    var text = dictionaryList[TextList.Count - 1];
+                    if (text.EndsWith(":")) text += field;
+                    else text += " " + field;
+                    dictionaryList[dictionaryList.Count - 1] = text;
+                }
+                else
+                    dictionaryList.Add(field);
+            }
+
+            foreach (var item in dictionaryList)
             {
                 var parts = item.Split(':');
                 if (parts.Length != 2) continue;

--- a/BankFileParsers/Classes/Detail.cs
+++ b/BankFileParsers/Classes/Detail.cs
@@ -121,7 +121,7 @@ namespace BankFileParsers
             {
                 if (dictionaryList.Count > 0 && !field.Contains(":"))
                 {
-                    var text = dictionaryList[TextList.Count - 1];
+                    var text = dictionaryList[dictionaryList.Count - 1];
                     if (text.EndsWith(":")) text += field;
                     else text += " " + field;
                     dictionaryList[dictionaryList.Count - 1] = text;

--- a/BankFileParsers/Classes/Detail.cs
+++ b/BankFileParsers/Classes/Detail.cs
@@ -38,11 +38,19 @@ namespace BankFileParsers
 
                 if (line.StartsWith("16"))
                 {
-                    line = line.Replace("/", "");
+                    if (!line.EndsWith("/"))
+                    {
+                        line += "/";
+                    }
                 }
                 else if (line.StartsWith("88"))
                 {
                     line = line.Substring(2);//.Replace("/", " ");
+
+                    if (!line.EndsWith("/"))
+                    {
+                        line += "/";
+                    }
                 }
                 else throw new Exception("I got a bad line: " + line);
                 lineData += line;
@@ -98,15 +106,7 @@ namespace BankFileParsers
             var fields = Text.Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries);
             foreach (var field in fields)
             {
-                if (TextList.Count > 0 && !field.Contains(":"))
-                {
-                    var text = TextList[TextList.Count - 1];
-                    if (text.EndsWith(":")) text += field;
-                    else text += " " + field;
-                    TextList[TextList.Count - 1] = text;
-                }
-                else
-                    TextList.Add(field);
+                TextList.Add(field);
             }
         }
 

--- a/BankFileParsers/Classes/Detail.cs
+++ b/BankFileParsers/Classes/Detail.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace BankFileParsers
 {
@@ -90,6 +91,8 @@ namespace BankFileParsers
 
             CreateTextList();
             CreateTextDictionary();
+
+            Text = ConcatenateTextLines();
         }
 
         private string LeftoverStackToString(Stack stack)
@@ -133,6 +136,26 @@ namespace BankFileParsers
                     }
                 }
             }
+        }
+
+        private string ConcatenateTextLines()
+        {
+            var fields = Text.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            var concatText = new StringBuilder();
+
+            foreach (var field in fields)
+            {
+                if (concatText.ToString().EndsWith(":"))
+                {
+                    concatText.Append(field);
+                }
+                else
+                {
+                    concatText.Append(" " + field);
+                }
+            }
+
+            return concatText.ToString();
         }
     }
 }


### PR DESCRIPTION
I have recently started using this library with our product as you have done quite a good job of mapping out all of the specifications making it easy and fast for us to consume a BAI2 report. For our use case though, we did run into a small issue that we were hoping we could have rectified and released. We want to be able to reference specific Text lines of a transaction when we know a specific piece of detail will be contained there:

This PR manipulates the Detail class to ensure the TextList is populated with each line from the Text field of the BAI report. Previously the TextList would only contain a single index if there were no ':' in the Text records of the file.

This work ensures that every 16 and 88 records of a transaction ends with a '/' if it doesn't currently exist and then splits on this to add each line to a separate index of the TextList. A new method was added to then split by the '/' again and concatenate the results into the Text field. Finally, logic was moved into the CreateTextDictionary method to ensure the dictionary would still be produced in the same manner prior to these changes.

Example results:
![BAIReportRecord](https://user-images.githubusercontent.com/23663929/133912947-161f0897-2c9b-42cd-8a86-dd7e36a67fa3.png)
![TranslatedBAIReport](https://user-images.githubusercontent.com/23663929/133912951-888fd64c-6460-4869-a4f9-e88f218ae8a6.png)

Happy to discuss further