### PR TITLE
This should fix #13.

### DIFF
--- a/BankFileParsers/Helpers/BaiFileHelpers.cs
+++ b/BankFileParsers/Helpers/BaiFileHelpers.cs
@@ -11,9 +11,11 @@ namespace BankFileParsers
 
         public static DateTime DateTimeFromFields(string date, string time)
         {
+            if (string.IsNullOrWhiteSpace(date) && string.IsNullOrWhiteSpace(time)) return DateTime.MinValue;
+
             // An end of day can be 9999, if it is they really ment 2400
             var dateString = date;
-            if (time == "9999") dateString += "2400";
+            if (time == "9999") time = "2400";
             if (time == string.Empty) dateString += "0000";
             else dateString += time;
 


### PR DESCRIPTION
It will return DateTime.MinValue if null or empty. I didn't want to change the signature and return a nullable