### PR TITLE
Add new method to overwrite TransactionDetail line with a new string.

### DIFF
--- a/BankFileParsers/Classes/BaiDetail.cs
+++ b/BankFileParsers/Classes/BaiDetail.cs
@@ -11,5 +11,14 @@ namespace BankFileParsers
             TransactionDetail = line;
             DetailContinuation = new List<string>();
         }
+
+        /// <summary>
+        /// Overwrite the TransactionDetail line with a new string
+        /// </summary>
+        /// <param name="line">New string to overwrite with</param>
+        public void SetTransactionDetail(string line)
+        {
+            TransactionDetail = line;
+        }
     }
 }


### PR DESCRIPTION
We have a use-case where we have to parse a BAI2 file --> Overwrite the "Customer Reference Number" in the TransactionDetail row with a unique ID --> Save to a new BAI2 file. 

This new method I added will be used for this; thank you for your work on this library. Much appreciated!