### PR TITLE
Feature/more additions

### DIFF
--- a/BankFileParsers/Parsers/BaiParser.cs
+++ b/BankFileParsers/Parsers/BaiParser.cs
@@ -9,10 +9,29 @@ namespace BankFileParsers
     {
         private string[] _data;
 
+        /// <summary>
+        /// Parse BAI2 file
+        /// </summary>
+        /// <param name="fileName">Full path of BAI2 file to parse</param>
+        /// <returns>A <see cref="BaiFile"/> object</returns>
+        /// <exception cref="Exception"></exception>
         public BaiFile Parse(string fileName)
         {
-            if (!File.Exists(fileName)) throw new Exception("File not found, nothing to parse");
-            _data = File.ReadAllLines(fileName);
+            if (!File.Exists(path: fileName)) throw new Exception(message: "File not found, nothing to parse");
+            _data = File.ReadAllLines(path: fileName);
+            return InternalParse();
+        }
+
+        /// <summary>
+        /// Parse text from a BAI2 file
+        /// </summary>
+        /// <param name="fileText">Text contents of BAI2 file</param>
+        /// <returns>A <see cref="BaiFile"/> object</returns>
+        /// <exception cref="Exception"></exception>
+        public BaiFile ParseText(string fileText)
+        {
+            // Extract all lines from file text by splitting on all possible newline chars
+            _data = fileText.Split(separator: new []{"\r\n", "\r", "\n", Environment.NewLine}, options: StringSplitOptions.None);
             return InternalParse();
         }
 

--- a/BankFileParsers/Parsers/BaiParser.cs
+++ b/BankFileParsers/Parsers/BaiParser.cs
@@ -105,6 +105,11 @@ namespace BankFileParsers
             return lines.ToArray();
         }
 
+        /// <summary>
+        /// Main parser logic
+        /// </summary>
+        /// <returns>A <see cref="BaiFile"/> object, contained parsed file data</returns>
+        /// <exception cref="NotImplementedException"></exception>
         private BaiFile InternalParse()
         {
             var bai = new BaiFile();

--- a/BankFileParsers/Parsers/BaiParser.cs
+++ b/BankFileParsers/Parsers/BaiParser.cs
@@ -23,7 +23,7 @@ namespace BankFileParsers
         }
 
         /// <summary>
-        /// Parse text from a BAI2 file
+        /// Parse contents of a BAI2 file
         /// </summary>
         /// <param name="fileText">Text contents of BAI2 file</param>
         /// <returns>A <see cref="BaiFile"/> object</returns>

--- a/BankFileParsers/Parsers/BaiParser.cs
+++ b/BankFileParsers/Parsers/BaiParser.cs
@@ -31,7 +31,7 @@ namespace BankFileParsers
         public BaiFile ParseText(string fileText)
         {
             // Extract all lines from file text by splitting on all possible newline chars
-            _data = fileText.Split(separator: new []{"\r\n", "\r", "\n", Environment.NewLine}, options: StringSplitOptions.None);
+            _data = fileText.Split(separator: new []{"\r\n", "\r", "\n", Environment.NewLine}, options: StringSplitOptions.RemoveEmptyEntries);
             return InternalParse();
         }
 

--- a/BankFileParsers/Parsers/BaiParser.cs
+++ b/BankFileParsers/Parsers/BaiParser.cs
@@ -35,6 +35,11 @@ namespace BankFileParsers
             return InternalParse();
         }
 
+        /// <summary>
+        /// Construct BAI2 file contents and write to given file.
+        /// </summary>
+        /// <param name="fileName">Full path of BAI2 file to write to</param>
+        /// <param name="data">BAI file data</param>
         public void Write(string fileName, BaiFile data)
         {
             var lines = new List<string>
@@ -63,6 +68,41 @@ namespace BankFileParsers
             lines.Add(data.FileTrailer);
 
             File.WriteAllLines(fileName, lines.ToArray());
+        }
+
+        /// <summary>
+        /// Construct and return BAI2 file contents as an array of file lines.
+        /// </summary>
+        /// <param name="data">BAI2 file data</param>
+        /// <returns>An array of strings, each corresponding to one line in BAI2 file</returns>
+        public string[] GetFileText(BaiFile data)
+        {
+            var lines = new List<string>
+            {
+                data.FileHeader
+            };
+            foreach (var group in data.Groups)
+            {
+                lines.Add(group.GroupHeader);
+                lines.AddRange(group.GroupContinuation);
+                foreach (var account in group.Accounts)
+                {
+                    lines.Add(account.AccountIdentifier);
+                    lines.AddRange(account.AccountContinuation);
+
+                    foreach (var detail in account.Details)
+                    {
+                        lines.Add(detail.TransactionDetail);
+                        lines.AddRange(detail.DetailContinuation);
+                    }
+
+                    lines.Add(account.AccountTrailer);
+                }
+                lines.Add(group.GroupTrailer);
+            }
+            lines.Add(data.FileTrailer);
+
+            return lines.ToArray();
         }
 
         private BaiFile InternalParse()

--- a/BankFileParsers/Parsers/BaiParser.cs
+++ b/BankFileParsers/Parsers/BaiParser.cs
@@ -10,7 +10,7 @@ namespace BankFileParsers
         private string[] _data;
 
         /// <summary>
-        /// Parse BAI2 file
+        /// Parse BAI2 file, given path of file.
         /// </summary>
         /// <param name="fileName">Full path of BAI2 file to parse</param>
         /// <returns>A <see cref="BaiFile"/> object</returns>
@@ -23,7 +23,7 @@ namespace BankFileParsers
         }
 
         /// <summary>
-        /// Parse contents of a BAI2 file
+        /// Parse contents of a BAI2 file.
         /// </summary>
         /// <param name="fileText">Text contents of BAI2 file</param>
         /// <returns>A <see cref="BaiFile"/> object</returns>
@@ -73,7 +73,7 @@ namespace BankFileParsers
         /// <summary>
         /// Construct and return BAI2 file contents as an array of file lines.
         /// </summary>
-        /// <param name="data">BAI2 file data</param>
+        /// <param name="data">BAI2 file data contained in a <see cref="BaiFile"/> object</param>
         /// <returns>An array of strings, each corresponding to one line in BAI2 file</returns>
         public string[] GetFileText(BaiFile data)
         {


### PR DESCRIPTION
I added two methods:

- ParseText() - takes BAI file contents as a string, instead of BAI file name
- GetFileText() - returns parsed BAI file contents as a string array, instead of writing to a file.

Some context for above changes:
I am building a REST web API that uses your BankFileParses library as back end, and does the following:

- Takes BAI file contents in a request body (ParseText() is needed for this)
- Replaces some data in the "TransactionDetail" lines of relevant records (my previous PR was for this)
- Returns "translated" BAI file contents as string[] (GetFileText() is needed for this)

All my changes were new additions, I did not change any of the existing code other than adding some XML comments. Thanks again for your work on this library!