### PR TITLE
Changed the way 88 continuation records can be handled without breaki…

### DIFF
--- a/BankFileParsers.Example/Program.cs
+++ b/BankFileParsers.Example/Program.cs
@@ -30,6 +30,10 @@ namespace BankFileParsers.Example
                     var newFileName = fileName.Replace(basePath, transPath);
                     Directory.CreateDirectory(Path.GetDirectoryName(newFileName));
                     parser.Write(newFileName, bai);
+
+                    BaiTranslator.BaiTranslator88LineHandler = BaiTranslator88LineHandler.TrimSlashNewLine;
+                    var trans = BaiTranslator.Translate(bai);
+                    var details = BaiTranslator.GetDetailInformation(trans);
                 }
                 catch { }
                 sw.Stop();

--- a/BankFileParsers/BankFileParsers.csproj
+++ b/BankFileParsers/BankFileParsers.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net4.5;netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net4.5;netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <AssemblyVersion>0.1.10</AssemblyVersion>
-    <FileVersion>0.1.10</FileVersion>
-    <Version>0.1.10</Version>
+    <AssemblyVersion>0.2.0</AssemblyVersion>
+    <FileVersion>0.2.0</FileVersion>
+    <Version>0.2.0</Version>
     <Authors>Ken Wilcox</Authors>
     <Description>Utility methods and classes for parsing common bank files</Description>
-    <Copyright>Copyright 2015-2022</Copyright>
+    <Copyright>Copyright 2015-2023</Copyright>
     <PackageProjectUrl>https://github.com/kenwilcox/BankFileParsers</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/kenwilcox/BankFileParsers</RepositoryUrl>

--- a/BankFileParsers/Classes/Detail.cs
+++ b/BankFileParsers/Classes/Detail.cs
@@ -89,24 +89,54 @@ namespace BankFileParsers
             // What's left on the stack?
             Text = LeftoverStackToString(stack);
 
-            CreateTextList();
-            CreateTextDictionary();
+            if (BaiTranslator.BaiTranslator88LineHandler == BaiTranslator88LineHandler.OldWay)
+            {
+                CreateTextList();
+                CreateTextDictionary();
 
-            Text = ConcatenateTextLines();
+                Text = ConcatenateTextLines();
+            }
+            else if (BaiTranslator.BaiTranslator88LineHandler == BaiTranslator88LineHandler.TrimSlashNewLine)
+            {
+                CreateTextListNewLine();
+                CreateTextDictionaryNewLine();
+            }
         }
 
         private string LeftoverStackToString(Stack stack)
         {
             var ret = "";
-            while (stack.Count > 0)
-                ret += stack.Pop().ToString();
+            if (BaiTranslator.BaiTranslator88LineHandler == BaiTranslator88LineHandler.OldWay)
+            {
+                while (stack.Count > 0)
+                {
+                    ret += stack.Pop().ToString();
+                }
+            }
+            else if (BaiTranslator.BaiTranslator88LineHandler == BaiTranslator88LineHandler.TrimSlashNewLine)
+            {
+                while (stack.Count > 0)
+                {
+                    ret += stack.Pop().ToString().TrimEnd('/') + Environment.NewLine;
+                }
+            }
             return ret;
         }
 
         private void CreateTextList()
         {
             // Now fill up the List
-            var fields = Text.Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries);
+            var fields = Text.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var field in fields)
+            {
+                TextList.Add(field);
+            }
+        }
+
+        private void CreateTextListNewLine()
+        {
+            // Now fill up the List
+            var fields = Text.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
             foreach (var field in fields)
             {
                 TextList.Add(field);
@@ -148,6 +178,23 @@ namespace BankFileParsers
                     catch
                     {
                         // I'm doing this as a helper, makes no sense if it crashes
+                    }
+                }
+            }
+        }
+
+        private void CreateTextDictionaryNewLine()
+        {
+            var list = Text.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+            foreach (var line in list)
+            {
+                var parts = line.Split(new[] { "  " }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (var part in parts)
+                {
+                    var kvp = part.Split(':');
+                    if (kvp.Length > 1)
+                    {
+                        TextDictionary.Add(kvp[0].Trim(), kvp[1].Trim());
                     }
                 }
             }

--- a/BankFileParsers/Helpers/BaiFileHelpers.cs
+++ b/BankFileParsers/Helpers/BaiFileHelpers.cs
@@ -85,7 +85,7 @@ namespace BankFileParsers
         {
             if (string.IsNullOrEmpty(trimString)) return target;
 
-            string result = target;
+            var result = target;
             while (result.StartsWith(trimString))
             {
                 result = result.Substring(trimString.Length);

--- a/BankFileParsers/Parsers/BaiTranslator.cs
+++ b/BankFileParsers/Parsers/BaiTranslator.cs
@@ -4,8 +4,23 @@ using System.Globalization;
 
 namespace BankFileParsers
 {
+    public enum BaiTranslator88LineHandler
+    {
+        /// <summary>
+        /// This is the old way continuation lines were handled
+        /// </summary>
+        OldWay,
+
+        /// <summary>
+        /// This way does a TrimEnd('/') and adds an Environment.NewLine
+        /// </summary>
+        TrimSlashNewLine,
+    }
+
     public class BaiTranslator
     {
+        public static BaiTranslator88LineHandler BaiTranslator88LineHandler = BaiTranslator88LineHandler.OldWay;
+
         public static TranslatedBaiFile Translate(BaiFile data)
         {
             return new TranslatedBaiFile(data);
@@ -158,7 +173,7 @@ namespace BankFileParsers
         /// <param name="data">The translated BAI object</param>
         /// <param name="dictionaryKeys">Any Keys in the Detail.TextDictionary (if any) you would like to export</param>
         /// <returns>A List of DetailSummary</returns>
-        public static List<DetailSummary> GetDetailInformation(TranslatedBaiFile data, List<string> dictionaryKeys)
+        public static List<DetailSummary> GetDetailInformation(TranslatedBaiFile data, List<string> dictionaryKeys = null)
         {
             var ret = new List<DetailSummary>();
             foreach (var group in data.Groups)
@@ -179,6 +194,10 @@ namespace BankFileParsers
                                     textDictionary.Add(key, detail.TextDictionary[key]);
                                 }
                             }
+                        }
+                        else if (BaiTranslator88LineHandler == BaiTranslator88LineHandler.TrimSlashNewLine)
+                        {
+                            textDictionary = detail.TextDictionary;
                         }
 
                         var ds = new DetailSummary()

--- a/BankFileParsers/Properties/AssemblyInfo.cs
+++ b/BankFileParsers/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.10.0")]
-[assembly: AssemblyFileVersion("0.1.10.0")]
-[assembly: AssemblyInformationalVersion("0.1.10.0")]
+[assembly: AssemblyVersion("0.2.0.0")]
+[assembly: AssemblyFileVersion("0.2.0.0")]
+[assembly: AssemblyInformationalVersion("0.2.0.0")]

--- a/BankFileParsers/pack.bat
+++ b/BankFileParsers/pack.bat
@@ -1,5 +1,5 @@
 REM del *.nupkg
 REM run the "Pack" option on the project in Visual Studio
 REM I do not know why the command line stopped working
-move bin\Release\BankFileParsers.0.1.10.nupkg .
-nuget push BankFileParsers.0.1.10.nupkg -Source https://api.nuget.org/v3/index.json
+move bin\Release\BankFileParsers.0.2.0.nupkg .
+nuget push BankFileParsers.0.2.0.nupkg -Source https://api.nuget.org/v3/index.json

--- a/README.md
+++ b/README.md
@@ -160,6 +160,15 @@ This is all it was intended to do - add an issue or pull request and we can make
 
 
 ## CHANGE LOG
+### [0.2.0] - 2023-05-31
+#### Changed - possible breaking change
+- Added net7.0 TFM (Target framework moniker)
+- I have a new bank, the format is quite a bit different. This version 'should not' break existing functionality, but I don't have your files, so I can't guarantee it. The change is how the BaiTranslator handles continuation records (88's). The old way (which is the default) just did a string += otherString. The new option does a TrimEnd('/') + Environment.NewLine. This made it WAY easier for me to handle that data. I also didn't want to pass values to several objects, so it's a static property (not really a fan, but easy).
+  - Setting `BaiTranslator.BaiTranslator88LineHandler = BaiTranslator88LineHandler.TrimSlashNewLine` before calling BaiTranslator.Translate will get you the new functionality.
+  - Leaving it alone, or setting it to `BaiTranslator.BaiTranslator88LineHandler = BaiTranslator88LineHandler.OldWay` works the old way. I tested this with several files and it still worked (woot).
+- The new Translator returns the full dictionary of items if it finds any, so you might not need to use keys. Keys still work however.
+- Sorry for the lack of imagination on my end.
+
 ### [0.1.10] - 2022-09-21
 #### Changed
 - Via PR #23 - added two methods:


### PR DESCRIPTION
Changed the way 88 continuation records can be handled without breaking older functionality
Translator no longer needs dictionary keys. If you are using the new handler then you will get everything back (if any).
Added net7.0 TFM
Changed the version to 0.2.0, just in case.